### PR TITLE
hpp include compatibility for jazzy/rolling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(ament_cmake REQUIRED)
 
 
 find_package(OpenCV 4 REQUIRED)
+find_package(example_interfaces REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(image_transport REQUIRED)
@@ -50,6 +51,7 @@ target_link_libraries(cv_camera_node ${Boost_LIBRARIES} cv_camera)
 ## Specify libraries to link a library or executable target against
 ament_target_dependencies(cv_camera
         rclcpp
+        example_interfaces
         sensor_msgs
         image_transport
         cv_bridge
@@ -60,6 +62,7 @@ ament_target_dependencies(cv_camera
 
 ament_target_dependencies(cv_camera_node
         rclcpp
+        example_interfaces
         sensor_msgs
         std_msgs
         OpenCV
@@ -89,5 +92,11 @@ install(TARGETS cv_camera cv_camera_node
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION include/
   )
+
+# Install launch files.
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME}/
+)
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,6 @@ find_package(rclcpp REQUIRED)
 find_package(image_transport REQUIRED)
 find_package(cv_bridge REQUIRED)
 find_package(std_msgs REQUIRED)
-find_package(cv_bridge REQUIRED)
 find_package(camera_info_manager REQUIRED)
 # find_package(roslint REQUIRED)
 find_package(builtin_interfaces REQUIRED)
@@ -50,23 +49,23 @@ target_link_libraries(cv_camera_node ${Boost_LIBRARIES} cv_camera)
 
 ## Specify libraries to link a library or executable target against
 ament_target_dependencies(cv_camera
-        "rclcpp"
-        "sensor_msgs"
-        "image_transport"
-        "cv_bridge"
-        "camera_info_manager"
-        "std_msgs"
-        "OpenCV"
+        rclcpp
+        sensor_msgs
+        image_transport
+        cv_bridge
+        camera_info_manager
+        std_msgs
+        OpenCV
 )
 
 ament_target_dependencies(cv_camera_node
-        "rclcpp"
-        "sensor_msgs"
-        "std_msgs"
-        "OpenCV"
-        "camera_info_manager"
-        "image_transport"
-        "cv_bridge"
+        rclcpp
+        sensor_msgs
+        std_msgs
+        OpenCV
+        camera_info_manager
+        image_transport
+        cv_bridge
 )
 
 #############

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-ROS OpenCV camera driver
+ROS FLIR OpenCV camera driver for Boson and Lepton
 ========================
 
-It is very easy to capture video device if we use `cv::VideoCapture` of OpenCV.
+A driver to interface FLIR Lepton and Boson thermal cameras using v4l over usb.
 
 cv_camera_node
 ------------------
@@ -9,9 +9,27 @@ cv_camera_node
 This node uses [camera_info_manager](http://wiki.ros.org/camera_info_manager) for dealing with camera_info.
 If no calibration data is set, it has dummy values except for width and height.
 
+### Installation and Setup
+
+For first-time set up of udev rules for the lepton or boson, run the following and unplug/replug the camera:
+
+```
+sudo sh -c "echo 'SUBSYSTEMS==\"usb\", ATTRS{idVendor}==\"1e4e\", ATTRS{idProduct}==\"0100\", SYMLINK+=\"pt1\", GROUP=\"usb\", MODE=\"666\"' > /etc/udev/rules.d/99-pt1.rules"
+```
+
+Often it's preferrable to use the serial number of a camera to ensure consistent ordering & calibration. To set up the driver to use SN#, plug each camera in in the order required, (ensuring no other USB cameras are plugged in with 'ls /dev/video*') and run the following command: 
+
+```
+udevadm info --name=/dev/video1 | grep 'E: ID_SERIAL_SHORT='
+```
+
+Then copy the whole SN# into the launch file param "~device_sn". If you do not see a number, check your udev rules as well as permissions on the device. Note that Leptons register two devices each, use the first (0, 2, 4... default behavior)
+
 ### Publish
 
-* `~image_raw` (*sensor_msgs/Image*)
+* `~image_raw` (*sensor_msgs/Image*) - Mono16 radiometric raw data
+* `~image_raw_viz` (*sensor_msgs/Image*) - colorized for visualization
+* `~image_raw_cal` (*sensor_msgs/Image*) - normalized and possibly inverted for spatial calibration
 * `~camera_info` (*sensor_msgs/CameraInfo*)
 
 ### Service
@@ -20,9 +38,8 @@ If no calibration data is set, it has dummy values except for width and height.
 
 ### Parameters
 
-* `~rate` (*double*, default: 30.0) – publish rate [Hz].
-* `~device_id` (*int*, default: 0) – capture device id.
-* `~device_path` (*string*, default: "") – path to camera device file, e. g. `/dev/video0`.
+* `~device_sn` (*string*, default: "") – serial number of IR camera to avoid id mismatches; see setup note.
+* `~device_id` (*int*, default: 0) – capture device id, fallback if serial number is not specified.
 * `~frame_id` (*string*, default: "camera") – `frame_id` of message header.
 * `~image_width` (*int*) – try to set capture image width.
 * `~image_height` (*int*) – try to set capture image height.
@@ -31,14 +48,13 @@ If no calibration data is set, it has dummy values except for width and height.
 * `~capture_delay` (*double*, default: 0) – estimated duration of capturing and receiving the image.
 * `~rescale_camera_info` (*bool*, default: false) – rescale camera calibration info automatically.
 
-Supports CV_CAP_PROP_*, by below params.
+Supports CV_CAP_PROP_*, by below params; however, most are irrelevant to the FLIR Lepton/Boson. See example launch files.
 
 * `~cv_cap_prop_pos_msec` (*double*)
 * `~cv_cap_prop_pos_avi_ratio` (*double*)
 * `~cv_cap_prop_frame_width` (*double*)
 * `~cv_cap_prop_frame_height` (*double*)
 * `~cv_cap_prop_fps` (*double*)
-* `~cv_cap_prop_fourcc` (*double*)
 * `~cv_cap_prop_frame_count` (*double*)
 * `~cv_cap_prop_format` (*double*)
 * `~cv_cap_prop_mode` (*double*)
@@ -73,10 +89,16 @@ This node works as nodelet (`cv_camera/CvCameraNodelet`).
 Contributors
 --------------------
 
+This builds on the OTL/cv_camera and Kapernikov/cv_camera drivers, with customization for thermal camera peculiarities.
+
 PR is welcome. I'll review your code to keep consistency, be patient.
 
+FLIR adaptation:
+* James Haley
+Original cv_camera repo authors: 
 * Oleg Kalachev
 * Mikael Arguedas
 * Maurice Meedendorp
 * Max Schettler
 * Lukas Bulwahn
+* Kapernikov

--- a/include/cv_camera/capture.h
+++ b/include/cv_camera/capture.h
@@ -7,12 +7,12 @@
 #include <string>
 
 #include <rclcpp/rclcpp.hpp>
-#include <cv_bridge/cv_bridge.h>
-#include <image_transport/image_transport.h>
+#include <cv_bridge/cv_bridge.hpp>
+#include <image_transport/image_transport.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/image_encodings.hpp>
 #include <opencv2/highgui/highgui.hpp>
-#include <camera_info_manager/camera_info_manager.h>
+#include <camera_info_manager/camera_info_manager.hpp>
 
 /**
  * @brief namespace of this package

--- a/include/cv_camera/capture.h
+++ b/include/cv_camera/capture.h
@@ -181,7 +181,7 @@ public:
 
   bool setY16();
 
-  void vizClickCallback(const geometry_msgs::msg::Point& pt);
+  void vizClickCallback(const geometry_msgs::msg::Point::SharedPtr pt);
 
 private:
   /**

--- a/include/cv_camera/capture.h
+++ b/include/cv_camera/capture.h
@@ -7,12 +7,27 @@
 #include <string>
 
 #include <rclcpp/rclcpp.hpp>
-#include <cv_bridge/cv_bridge.hpp>
-#include <image_transport/image_transport.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/image_encodings.hpp>
 #include <opencv2/highgui/highgui.hpp>
+
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
+#include <cv_bridge/cv_bridge.h>
+#endif
+
+#if __has_include(<image_transport/image_transport.hpp>)
+#include <image_transport/image_transport.hpp>
+#else
+#include <image_transport/image_transport.h>
+#endif
+
+#if __has_include(<camera_info_manager/camera_info_manager.hpp>)
 #include <camera_info_manager/camera_info_manager.hpp>
+#else
+#include <camera_info_manager/camera_info_manager.h>
+#endif
 
 /**
  * @brief namespace of this package

--- a/include/cv_camera/capture.h
+++ b/include/cv_camera/capture.h
@@ -55,10 +55,18 @@ public:
   /**
    * @brief Open capture device with device name.
    *
+   * @param device_path path of the camera device
+   * @throw cv_camera::DeviceError device open failed
+   */
+  void open(const std::string &device_path);
+
+  /**
+   * @brief Open capture device with device name.
+   *
    * @param device_sn path of the camera device
    * @throw cv_camera::DeviceError device open failed
    */
-  void open(const std::string &device_sn);
+  void search(const std::string &device_sn);
 
   /**
    * @brief Load camera info from file.

--- a/launch/cv_camera_node_launch.xml
+++ b/launch/cv_camera_node_launch.xml
@@ -1,21 +1,25 @@
 <launch>
-    <arg name="frame_id" default="ir_0"/>
+    <arg name="frame_id" default="camera"/>
     <arg name="device_id" default="0"/>
-    <arg name="device_sn" default=""/>  <!-- e.g.: 801c0030-5112-3039-3433-373300000000 -->
+    <arg name="device_sn" default=""/>  
+    <!-- e.g.: 801c0030-5112-3039-3433-373300000000  for lepton, or 28422 for boson-->
+    <!-- Find with 'udevadm info /dev/video0' or whatever device is the IR cam-->
+    <arg name="camera_info_url" default="file://$(env HOME)/.ros/camera_info/camera.yaml"/>
     <arg name="mirror_horizontal" default="false"/>
     <arg name="mirror_vertical" default="false"/>
     <arg name="pub_vizualization" default="true"/>
     <arg name="pub_calibration" default="false"/>
     <node pkg="cv_camera" exec="cv_camera_node" name="cv_camera_node" output="screen">
-        <param name="frame_id" value="$(var frame_id)" />
-        <param name="device_id" value="$(var device_id)" />
-        <param name="device_sn" value="$(var device_sn)" />
-        <param name="cv_cap_prop_format" value="-1"/>
-        <param name="cv_cap_prop_convert_rgb" value="0"/>
-        <param name="mirror_horizontal" value="$(var mirror_horizontal)"/>
-        <param name="mirror_vertical" value="$(var mirror_vertical)"/>
-        <param name="pub_vizualization" value="$(var pub_vizualization)"/>
-        <param name="pub_calibration" value="$(var pub_calibration)"/>
+        <param name="frame_id" value="$(var frame_id)"  type="str"/>
+        <param name="device_id" value="$(var device_id)"  type="int"/>
+        <param name="device_sn" value="$(var device_sn)"  type="str"/>
+        <param name="camera_info_url" value="$(var camera_info_url)"  type="str"/>
+        <param name="cv_cap_prop_format" value="-1" type="float"/>
+        <param name="cv_cap_prop_convert_rgb" value="0" type="float"/>
+        <param name="mirror_horizontal" value="$(var mirror_horizontal)"  type="bool"/>
+        <param name="mirror_vertical" value="$(var mirror_vertical)"  type="bool"/>
+        <param name="pub_vizualization" value="$(var pub_vizualization)"  type="bool"/>
+        <param name="pub_calibration" value="$(var pub_calibration)"  type="bool"/>
     </node>
 
 </launch>

--- a/launch/cv_camera_node_launch.xml
+++ b/launch/cv_camera_node_launch.xml
@@ -1,7 +1,8 @@
 <launch>
     <arg name="frame_id" default="camera"/>
+    <arg name="device_sn" default=""/> 
+    <arg name="device_path" default=""/>
     <arg name="device_id" default="0"/>
-    <arg name="device_sn" default=""/>  
     <!-- e.g.: 801c0030-5112-3039-3433-373300000000  for lepton, or 28422 for boson-->
     <!-- Find with 'udevadm info /dev/video0' or whatever device is the IR cam-->
     <arg name="camera_info_url" default="file://$(env HOME)/.ros/camera_info/camera.yaml"/>
@@ -11,8 +12,9 @@
     <arg name="pub_calibration" default="false"/>
     <node pkg="cv_camera" exec="cv_camera_node" name="cv_camera_node" output="screen">
         <param name="frame_id" value="$(var frame_id)"  type="str"/>
-        <param name="device_id" value="$(var device_id)"  type="int"/>
         <param name="device_sn" value="$(var device_sn)"  type="str"/>
+        <param name="device_path" value="$(var device_path)" type='str'/>
+        <param name="device_id" value="$(var device_id)" type='str'/>
         <param name="camera_info_url" value="$(var camera_info_url)"  type="str"/>
         <param name="cv_cap_prop_format" value="-1" type="float"/>
         <param name="cv_cap_prop_convert_rgb" value="0" type="float"/>

--- a/launch/cv_camera_node_launch.xml
+++ b/launch/cv_camera_node_launch.xml
@@ -1,0 +1,21 @@
+<launch>
+    <arg name="frame_id" default="ir_0"/>
+    <arg name="device_id" default="0"/>
+    <arg name="device_sn" default=""/>  <!-- e.g.: 801c0030-5112-3039-3433-373300000000 -->
+    <arg name="mirror_horizontal" default="false"/>
+    <arg name="mirror_vertical" default="false"/>
+    <arg name="pub_vizualization" default="true"/>
+    <arg name="pub_calibration" default="false"/>
+    <node pkg="cv_camera" exec="cv_camera_node" name="cv_camera_node" output="screen">
+        <param name="frame_id" value="$(var frame_id)" />
+        <param name="device_id" value="$(var device_id)" />
+        <param name="device_sn" value="$(var device_sn)" />
+        <param name="cv_cap_prop_format" value="-1"/>
+        <param name="cv_cap_prop_convert_rgb" value="0"/>
+        <param name="mirror_horizontal" value="$(var mirror_horizontal)"/>
+        <param name="mirror_vertical" value="$(var mirror_vertical)"/>
+        <param name="pub_vizualization" value="$(var pub_vizualization)"/>
+        <param name="pub_calibration" value="$(var pub_calibration)"/>
+    </node>
+
+</launch>

--- a/package.xml
+++ b/package.xml
@@ -24,7 +24,7 @@
   <build_depend>camera_info_manager</build_depend>
   <exec_depend>camera_info_manager</exec_depend>
 
-  <exec_depend>v4l2-utils</exec_depend>
+  <exec_depend>v4l-utils</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,8 @@
   <build_depend>camera_info_manager</build_depend>
   <exec_depend>camera_info_manager</exec_depend>
 
+  <exec_depend>v4l2-utils</exec_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -3,6 +3,7 @@
 #include "cv_camera/capture.h"
 #include <sstream>
 #include <string>
+#include <regex>
 
 namespace cv_camera
 {
@@ -19,6 +20,11 @@ Capture::Capture(rclcpp::Node::SharedPtr node, const std::string& topic_name, ui
   , buffer_size_(buffer_size)
   , info_manager_(node_.get(), frame_id)
   , capture_delay_(rclcpp::Duration(rclcpp::Duration::from_seconds(node_->get_parameter_or("capture_delay", 0.0))))
+  , mirror_horizontal_(node_->get_parameter_or("mirror_horizontal", false))
+  , mirror_vertical_(node_->get_parameter_or("mirror_vertical", false))
+  , publish_viz_(node_->get_parameter_or("pub_vizualization", true))
+  , publish_cal_(node_->get_parameter_or("pub_calibration", false))
+  , invert_cal_(node_->get_parameter_or("invert_calibration", false))
 {
 }
 
@@ -78,7 +84,7 @@ void Capture::rescaleCameraInfo(uint width, uint height)
 
 void Capture::open(int32_t device_id)
 {
-  cap_.open(device_id);
+  cap_.open(device_id,cv::CAP_V4L2);
   if (!cap_.isOpened())
   {
     std::stringstream stream;
@@ -86,18 +92,55 @@ void Capture::open(int32_t device_id)
     throw DeviceError(stream.str());
   }
   pub_ = it_.advertiseCamera(topic_name_, buffer_size_);
+  if (publish_viz_){pub_viz_ = it_.advertiseCamera(topic_name_+"_viz", buffer_size_);}
+  if (publish_cal_){pub_cal_ = it_.advertiseCamera(topic_name_+"_cal", buffer_size_);}
 
   loadCameraInfo();
 }
 
-void Capture::open(const std::string &device_path)
+void Capture::open(const std::string &device_sn)
 {
-  cap_.open(device_path, cv::CAP_V4L);
+  // Search USB devices for matching serial number using udevadm output
+  std::array<char, 128> buffer;
+  int device_open_id;
+  std::string result, current_line, device_num;
+
+  for(int i = 0; i < 30; i++){
+  std::string cmdstr = std::string("udevadm info --name=/dev/video") + std::to_string(i);
+  const char* cmd = cmdstr.c_str();
+  std::shared_ptr<FILE> pipe(popen(cmd, "r"), pclose);
+  if (!pipe) throw std::runtime_error("popen() failed!");
+  while (!feof(pipe.get())) {
+      if (fgets(buffer.data(), 128, pipe.get()) != nullptr)
+          result += buffer.data();
+  }
+  std::istringstream lsusboutut{result};
+
+  while (std::getline(lsusboutut, current_line))
+  {
+    std::smatch m; 
+    if(std::regex_search(current_line, m, std::regex("N: video(\\d+)"))){
+      device_num = m[1].str();
+    }
+
+    std::smatch mm; 
+    if(std::regex_search(current_line, mm, std::regex(device_sn.c_str()))){
+      device_open_id = std::stoi(device_num);
+      break;
+    }
+  }
+  // TODO: this doesn't check if multiple devices match the serial, just uses the last
+  }
+  RCLCPP_INFO(node_->get_logger(),"Found device with matching serial number: /dev/video%s, %s\n", device_num.c_str(), device_sn.c_str());
+
+  cap_.open(device_open_id, cv::CAP_V4L2);
   if (!cap_.isOpened())
   {
-    throw DeviceError("device_path " + device_path + " cannot be opened");
+    throw DeviceError("device_sn " + device_sn + " cannot be opened");
   }
   pub_ = it_.advertiseCamera(topic_name_, buffer_size_);
+  if (publish_viz_){pub_viz_ = it_.advertiseCamera(topic_name_+"_viz", buffer_size_);}
+  if (publish_cal_){pub_cal_ = it_.advertiseCamera(topic_name_+"_cal", buffer_size_);}
 
   loadCameraInfo();
 }
@@ -117,6 +160,8 @@ void Capture::openFile(const std::string &file_path)
     throw DeviceError(stream.str());
   }
   pub_ = it_.advertiseCamera(topic_name_, buffer_size_);
+  if (publish_viz_){pub_viz_ = it_.advertiseCamera(topic_name_+"_viz", buffer_size_);}
+  if (publish_cal_){pub_cal_ = it_.advertiseCamera(topic_name_+"_cal", buffer_size_);}
 
   loadCameraInfo();
 }
@@ -127,7 +172,29 @@ bool Capture::capture()
   {
     rclcpp::Clock system_clock(RCL_SYSTEM_TIME);
     rclcpp::Time stamp = system_clock.now() - capture_delay_;
-    bridge_.encoding = enc::BGR8;
+
+    // Trim off lepton metadata
+    // int cropheight = bridge_.image.size().height - 2;
+    // int cropwidth = bridge_.image.size().width;
+    // bridge_.image = bridge_.image(cv::Range(0,cropheight),cv::Range(0,cropwidth));
+
+    // Mirror
+    if (mirror_horizontal_)
+    {
+      cv_bridge::CvImage tmp_;
+      cv::flip(bridge_.image, tmp_.image, 1);
+      bridge_.image = tmp_.image;
+    }
+
+    if (mirror_vertical_)
+    {
+      cv_bridge::CvImage tmp_;
+      cv::flip(bridge_.image, tmp_.image, 0);
+      bridge_.image = tmp_.image;
+    }
+
+    // Construct header
+    bridge_.encoding = enc::MONO16;
     bridge_.header.stamp = stamp;
     bridge_.header.frame_id = frame_id_;
 
@@ -157,6 +224,72 @@ bool Capture::capture()
     info_.header.stamp = stamp;
     info_.header.frame_id = frame_id_;
 
+    // Get high & low IR intensities
+    double minVal; 
+    double maxVal; 
+    cv::Point minLoc; 
+    cv::Point maxLoc;
+
+    minMaxLoc( bridge_.image, &minVal, &maxVal, &minLoc, &maxLoc );
+    example_interfaces::msg::Float64 maxmsg;
+    maxmsg.data = maxVal;
+    this->pubmax->publish(maxmsg);
+
+    example_interfaces::msg::Float64 minmsg;
+    minmsg.data = minVal;
+    this->pubmin->publish(minmsg);
+
+    if (publish_viz_)
+    {
+      // Make a pretty image
+      cv_bridge::CvImage tmp_;
+      cv::normalize(bridge_.image, tmp_.image, 0, 65535, cv::NORM_MINMAX);
+      tmp_.image.convertTo(tmp_.image,CV_8UC1,1/255.0); //CV_32F
+      cv::applyColorMap(tmp_.image, bridge_viz_.image, cv::COLORMAP_HOT);
+
+      bridge_viz_.encoding = enc::BGR8;
+      bridge_viz_.header.stamp = stamp;
+      bridge_viz_.header.frame_id = frame_id_;
+
+      info_viz_ = info_;
+
+      // Publish temperature at picked point
+      uint16_t temp_mk = bridge_.image.at<uint16_t>(pty,ptx);
+      example_interfaces::msg::Float64 intensitymsg;
+      intensitymsg.data = static_cast< float >( temp_mk );
+      this->pickedpoint->publish(intensitymsg);
+      
+      // sensor_msgs::Temperature tempmsg;
+      // tempmsg.temperature = static_cast< float >( temp_mk ) / 100 - 271.15;
+      // tempmsg.header.stamp = stamp;
+      // pointtemp.publish(tempmsg);
+
+      // Draw crosshair
+      cv::line(bridge_viz_.image, cv::Point(ptx - 5, pty), cv::Point(ptx - 2, pty), cvScalar(117,79,142), 1);
+      cv::line(bridge_viz_.image, cv::Point(ptx + 5, pty), cv::Point(ptx + 2, pty), cvScalar(117,79,142), 1);
+      cv::line(bridge_viz_.image, cv::Point(ptx, pty - 5), cv::Point(ptx, pty - 2), cvScalar(117,79,142), 1);
+      cv::line(bridge_viz_.image, cv::Point(ptx, pty + 5), cv::Point(ptx, pty + 2), cvScalar(117,79,142), 1);
+
+    }
+
+    if (publish_cal_)
+    {
+      // Make an image useful for calibrating the camera
+      cv_bridge::CvImage tmpcal_;
+      cv::normalize(bridge_.image, bridge_cal_.image, 0, 65535, cv::NORM_MINMAX);
+      bridge_cal_.image.convertTo(bridge_cal_.image,CV_8UC1,1/255.0); 
+      if(invert_cal_){
+        cv::bitwise_not(bridge_cal_.image, bridge_cal_.image);
+      }
+      // cv::equalizeHist( bridge_cal_.image, bridge_cal_.image );
+      cv::GaussianBlur( bridge_cal_.image, bridge_cal_.image, cv::Size( 3, 3 ), 0, 0 );
+
+      bridge_cal_.encoding = enc::MONO8;
+      bridge_cal_.header.stamp = stamp;
+      bridge_cal_.header.frame_id = frame_id_;
+
+      info_cal_ = info_;
+    }
     return true;
   }
   return false;
@@ -165,6 +298,12 @@ bool Capture::capture()
 void Capture::publish()
 {
   pub_.publish(*getImageMsgPtr(), info_);
+  if(publish_viz_){
+    pub_viz_.publish(*getImageVizMsgPtr(), info_viz_);
+  }
+  if(publish_cal_){
+    pub_cal_.publish(*getImageCalMsgPtr(), info_cal_);
+  }
 }
 
 bool Capture::setPropertyFromParam(int property_id, const std::string &param_name)
@@ -179,6 +318,24 @@ bool Capture::setPropertyFromParam(int property_id, const std::string &param_nam
     }
   }
   return true;
+}
+
+bool Capture::setY16()
+{
+  if (cap_.isOpened())
+  {
+    double yval = cv::VideoWriter::fourcc('Y','1','6',' ');
+    RCLCPP_INFO(node_->get_logger(),"setting property Y16 = %lf", yval);
+    cap_.set(cv::CAP_PROP_FOURCC, cv::VideoWriter::fourcc('Y','1','6',' '));
+  }
+  return true;
+}
+
+void Capture::vizClickCallback(const geometry_msgs::msg::Point& pt)
+{
+  RCLCPP_INFO(node_->get_logger(),"Monitoring point temperature at: (%f,%f)",pt.x,pt.y);
+  ptx = static_cast<int>(pt.x);
+  pty = static_cast<int>(pt.y);
 }
 
 } // namespace cv_camera

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -22,7 +22,7 @@ void Driver::setup()
 {
   double hz(DEFAULT_RATE);
   int32_t device_id(0);
-  std::string device_path("");
+  std::string device_sn("");
   std::string frame_id("camera");
   std::string file_path("");
 
@@ -42,9 +42,9 @@ void Driver::setup()
   {
     camera_->openFile(file_path);
   }
-  else if (private_node_->get_parameter("device_path", device_path) && device_path != "")
+  else if (private_node_->get_parameter("device_sn", device_sn) && device_sn != "")
   {
-    camera_->open(device_path);
+    camera_->open(device_sn);
   }
   else
   {
@@ -65,12 +65,14 @@ void Driver::setup()
     }
   }
 
+  camera_->setY16();
+  
   camera_->setPropertyFromParam(cv::CAP_PROP_POS_MSEC, "cv_cap_prop_pos_msec");
   camera_->setPropertyFromParam(cv::CAP_PROP_POS_AVI_RATIO, "cv_cap_prop_pos_avi_ratio");
   camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_WIDTH, "cv_cap_prop_frame_width");
   camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_HEIGHT, "cv_cap_prop_frame_height");
   camera_->setPropertyFromParam(cv::CAP_PROP_FPS, "cv_cap_prop_fps");
-  camera_->setPropertyFromParam(cv::CAP_PROP_FOURCC, "cv_cap_prop_fourcc");
+  // camera_->setPropertyFromParam(cv::CAP_PROP_FOURCC, "cv_cap_prop_fourcc");
   camera_->setPropertyFromParam(cv::CAP_PROP_FRAME_COUNT, "cv_cap_prop_frame_count");
   camera_->setPropertyFromParam(cv::CAP_PROP_FORMAT, "cv_cap_prop_format");
   camera_->setPropertyFromParam(cv::CAP_PROP_MODE, "cv_cap_prop_mode");

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -22,11 +22,13 @@ void Driver::setup()
 {
   double hz(DEFAULT_RATE);
   int32_t device_id(0);
+  std::string device_id_str("");
   std::string device_sn("");
+  std::string device_path("");
   std::string frame_id("camera");
   std::string file_path("");
 
-  private_node_->get_parameter("device_id", device_id);
+  private_node_->get_parameter("device_id", device_id_str);
   private_node_->get_parameter("frame_id", frame_id);
   private_node_->get_parameter("rate", hz);
 
@@ -44,10 +46,17 @@ void Driver::setup()
   }
   else if (private_node_->get_parameter("device_sn", device_sn) && device_sn != "")
   {
-    camera_->open(device_sn);
+    camera_->search(device_sn);
+  }
+  else if (private_node_->get_parameter("device_path", device_path) && device_path != "")
+  {
+    camera_->open(device_path);
   }
   else
   {
+    if(device_id_str != ""){
+      device_id = std::stoi(device_id_str);
+    }
     camera_->open(device_id);
   }
   if (private_node_->get_parameter("image_width", image_width))


### PR DESCRIPTION
When building in jazzy/rolling, three libraries have moved to an hpp file instead of .h, which crashes the build (cv_bridge, image_transport, and camera_calibration).

To keep back compatibility, made an optional include to find .h if the .hpp isn't found.